### PR TITLE
Patched Pose Construct Reference

### DIFF
--- a/src/lib4253/Trajectory/Geometry/Pose.cpp
+++ b/src/lib4253/Trajectory/Geometry/Pose.cpp
@@ -52,8 +52,8 @@ bool Pose::operator!=(const Pose& rhs) const{
 }
 
 void Pose::operator=(const Pose& rhs){
-    translation = getTranslation();
-    rotation = getRotation();
+    translation = rhs.getTranslation();
+    rotation = rhs.getRotation();
 }
 
 Point Pose::closestTo(const Point& rhs) const{


### PR DESCRIPTION
The `getTranslation` and `getRotation` methods of the Pose equal operator is referencing from the wrong object. 